### PR TITLE
Add Daniel Schroeder to PowerShell Mastodon list

### DIFF
--- a/MastoPosh.CSV
+++ b/MastoPosh.CSV
@@ -17,3 +17,4 @@ Cody Konior,@codykonior@mastodon.social,Y,Y,"EN-AU"
 Thorsten Butz,@thorstenbutz@twit.social,Y,Y,"DE,NL,EN,en-GB,en-US,de-DE,de-AT,de-CH,nl-NL"
 Joel Bennett,@jaykul@huddledmasses.org,Y,Y,EN
 Henrik Hansson,spidertheswede@twit.social,Y,Y,"EN,sv-SE"
+Daniel Schroeder,@deadlydog@hachyderm.io,Y,Y,"EN"


### PR DESCRIPTION
Daniel Schroeder has blogged about PowerShell quite a bit at https://blog.danskingdom.com and loves to interact with others on social media about PowerShell.